### PR TITLE
Allow to specify logging level for development evmos node

### DIFF
--- a/scripts/run_developer_image.sh
+++ b/scripts/run_developer_image.sh
@@ -15,7 +15,7 @@ EVMOS_NETWORK_KEYS_PATH=/root/.evmosd/zama/keys/network-fhe-keys ./prepare_valid
 
 # start the node
 TRACE=""
-LOGLEVEL="info"
+LOGLEVEL="${LOGLEVEL:-info}"
 
 ./fhevm-decryptions-db &
 


### PR DESCRIPTION
User can use custom logging level via -e LOGLEVEL environment variable which defaults to info

@leventdem 